### PR TITLE
Added an example of deadcode elimination

### DIFF
--- a/src/examples/02/modules/main.js
+++ b/src/examples/02/modules/main.js
@@ -1,0 +1,4 @@
+import { getStringTag } from './unbind';
+import { arrayTag } from './tags';
+
+console.log( getStringTag( [] ) === arrayTag ); // true

--- a/src/examples/02/modules/tags.js
+++ b/src/examples/02/modules/tags.js
@@ -1,0 +1,10 @@
+// A number of StringTags.
+export const
+	arrayTag = '[object Array]',
+	dateTag = '[object Date]',
+	functionTag = '[object Function]',
+	mathTag = '[object Math]',
+	nullTag = '[object Null]',
+	regexTag = '[object RegExp]',
+	stringTag = '[object String]',
+	undefinedTag = '[object Undefined]';

--- a/src/examples/02/modules/unbind.js
+++ b/src/examples/02/modules/unbind.js
@@ -1,0 +1,12 @@
+// Create functions from prototype methods, to avoid using call.
+const unbind = Function.prototype.bind.bind(Function.prototype.call);
+
+export const slice = unbind(Array.prototype.slice);
+
+// Check if the first argument has a given property name.
+export const hasOwn = unbind(Object.prototype.hasOwnProperty);
+
+// Get the string tag of an object.
+export const getStringTag = unbind(Object.prototype.toString);
+
+export default unbind;

--- a/src/examples/02/name
+++ b/src/examples/02/name
@@ -1,0 +1,1 @@
+deadcode-elimination


### PR DESCRIPTION
I thought this would work like a charm, but I think I might have discovered a bug. I'd expect Rollup to strip away all string tags except for `arrayTag`. Apparently it leaves them in. The same goes for `unbind.js`. I understand that we may have to keep all invocations of `unbind` since they could "mutate" some internal state.

Interestingly, it also seems to fail if I import `'./unbind.js'` from main, instead of just `'./unbind'`.