### PR TITLE
flexible height editors

### DIFF
--- a/src/app/Module.html
+++ b/src/app/Module.html
@@ -36,6 +36,14 @@
 		width: 100%;
 		height: 100px;
 	}
+
+	.CodeMirror {
+		height: auto;
+	}
+
+	.CodeMirror-scroll {
+		max-height: 80vh;
+	}
 </style>
 
 <script>
@@ -48,7 +56,8 @@
 			let updating = false;
 
 			const editor = CodeMirror.fromTextArea( this.find( 'textarea' ), {
-				lineNumbers: true
+				lineNumbers: true,
+				lineWrapping: true
 			});
 
 			editor.on( 'change', instance => {

--- a/src/app/Output.html
+++ b/src/app/Output.html
@@ -16,6 +16,7 @@
 		oncomplete () {
 			let cm = CodeMirror( this.find( '#editor' ), {
 				lineNumbers: true,
+				lineWrapping: true,
 				readOnly: true
 			});
 

--- a/src/files/index.html
+++ b/src/files/index.html
@@ -25,6 +25,7 @@
 		main {
 			min-height: 100%;
 			overflow: hidden;
+			padding: 1em;
 		}
 
 		footer {


### PR DESCRIPTION
This PR collapses editors down to their minimum height, and allows them to expand up to 80% of the viewport height (at which point they scroll). It also adds some horizontal padding so that the user is always able to scroll outside the editor