### PR TITLE
store state in hash fragment – closes #4

### DIFF
--- a/src/app/Input/index.html
+++ b/src/app/Input/index.html
@@ -45,6 +45,8 @@
 		oninit () {
 			this.observe({
 				selectedExample: example => {
+					if ( !example ) return;
+
 					const modules = Object.keys( example.modules ).map( key => {
 						return {
 							name: `${key}.js`,

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -3,14 +3,47 @@ import Output from './Output/index';
 import Footer from './Footer';
 import examples from './examples';
 import { dirname, extname, resolve } from './utils/path';
+import examplesMatch from './utils/examplesMatch';
+
+// recover state from hash fragment
+const json = window.location.hash.slice( 1 );
+let saved;
+let selectedExample;
+try {
+	saved = JSON.parse( json );
+	let example;
+
+	// does this match an existing example?
+	for ( let i = 0; i < examples.length; i += 1 ) {
+		example = examples[i];
+
+		if ( examplesMatch( example.modules, saved.modules ) ) {
+			selectedExample = example;
+			break;
+		}
+	}
+} catch ( err ) {
+	// do nothing
+}
 
 const input = new Input({
 	el: '.input',
-	data: { examples }
+	data: {
+		examples,
+		selectedExample
+	}
 });
 
+if ( saved ) input.set( 'modules', saved.modules );
+
 const output = new Output({
-	el: '.output'
+	el: '.output',
+	data: {
+		options: saved ? saved.options : {
+			format: 'amd',
+			moduleName: 'myBundle'
+		}
+	}
 });
 
 const footer = new Footer({
@@ -26,6 +59,9 @@ function update () {
 	modules.forEach( module => {
 		moduleById[ module.name ] = module;
 	});
+
+	// save state as hash fragment
+	window.location.hash = JSON.stringify({ options, modules });
 
 	/*global rollup */
 	rollup.rollup({

--- a/src/app/utils/examplesMatch.js
+++ b/src/app/utils/examplesMatch.js
@@ -1,0 +1,18 @@
+export default function examplesMatch ( exampleModules, saved ) {
+	let i = saved.length;
+	if ( !i ) return false;
+
+	let name;
+
+	while ( i-- ) {
+		name = saved[i].name.replace( /\.js$/, '' );
+
+		const a = exampleModules[ name ];
+		const b = saved[i].code;
+
+		if ( !a ) return false;
+		if ( a.trim() !== b.trim() ) return false;
+	}
+
+	return true;
+}

--- a/src/app/utils/path.js
+++ b/src/app/utils/path.js
@@ -19,7 +19,7 @@ export function dirname ( path ) {
 export function extname ( path ) {
 	const match = /\.[^\.]+$/.exec( path );
 	if ( !match ) return '';
-	return match[0]
+	return match[0];
 }
 
 export function relative ( from, to ) {


### PR DESCRIPTION
Figured we might as well take the simple route and steal the es6-module-transpiler demo trick.