### PR TITLE
Show the current Rollup version in the UI

### DIFF
--- a/src/app/main.js
+++ b/src/app/main.js
@@ -9,6 +9,9 @@ import debounce from './utils/debounce';
 const supported = !!window.Promise;
 
 if ( supported ) {
+	const small = document.querySelector('header small');
+	small.innerHTML = `(${rollup.VERSION}) ${small.innerHTML}`;
+
 	console.log( `running Rollup version %c${rollup.VERSION}`, 'font-weight: bold' );
 
 	// recover state from hash fragment

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -9,8 +9,7 @@ import debounce from './utils/debounce';
 const supported = !!window.Promise;
 
 if ( supported ) {
-	const small = document.querySelector('header small');
-	small.innerHTML = `(${rollup.VERSION}) ${small.innerHTML}`;
+	document.querySelector('header h1 small').innerHTML = `v${rollup.VERSION}`;
 
 	console.log( `running Rollup version %c${rollup.VERSION}`, 'font-weight: bold' );
 

--- a/src/files/index.html
+++ b/src/files/index.html
@@ -14,7 +14,7 @@
 
 <body>
 	<header>
-		<h1>rollup.js</h1>
+		<h1>rollup.js <small style="font-size:small;opacity:.7;"></small></h1>
 		<small>the next-generation JavaScript module bundler</small>
 
 		<a class='github' href='https://github.com/rollup/rollup'>GitHub</a>


### PR DESCRIPTION
I know that the current version is displayed in the console, but it wouldn't hurt to display it in the UI for those who don't open theirs.

<img width="340" alt="screen shot 2015-10-27 at 15 31 12" src="https://cloud.githubusercontent.com/assets/703602/10761022/cc036fc0-7cbf-11e5-89ef-f5b7f264a9a3.png">

It would be better to do it declaratively. Do you think I should create a Ractive component instead?