### PR TITLE
use `--save-dev` in npm instructions

### DIFF
--- a/src/guide/05-using-rollup-with-npm.md
+++ b/src/guide/05-using-rollup-with-npm.md
@@ -24,7 +24,7 @@ First, we need an file package.json, thereunto run the command
 
 Then just install the rollup
 
-  ``npm install --save rollup``
+  ``npm install --save-dev rollup``
 
 Create your file using of module es2015
 


### PR DESCRIPTION
This flag is used for dependencies that are needed a build-time, vs. run-time.