### PR TITLE
Fix homepage on Safari

### DIFF
--- a/src/files/index.html
+++ b/src/files/index.html
@@ -56,7 +56,7 @@
 	<!-- load selected version of Rollup, then the app -->
 	<script>
 		function loadScript ( src ) {
-			return new Promise( ( fulfil, reject ) => {
+			return new Promise( function ( fulfil, reject ) {
 				var script = document.createElement( 'script' );
 				script.onload = fulfil;
 				script.onerror = reject;

--- a/src/styles/blurb.css
+++ b/src/styles/blurb.css
@@ -8,9 +8,15 @@
 	clear: fix;
 
 	.block {
-		flex: 1 0 25%;
+    @media (min-width: 60rem) {
+      flex: 1 0 25%;
+      width: 25%;
+    }
+    @media (min-width: 45rem) {
+      flex: 1 0 50%;
+      width: 50%;
+    }
 		padding: 0 0.5em;
-		width: 25%;
 		min-width: 15rem;
 		@media (max-width: 15rem) {
 			min-width: 100%;

--- a/src/styles/blurb.css
+++ b/src/styles/blurb.css
@@ -8,14 +8,14 @@
 	clear: fix;
 
 	.block {
-    @media (min-width: 60rem) {
-      flex: 1 0 25%;
-      width: 25%;
-    }
-    @media (min-width: 45rem) {
-      flex: 1 0 50%;
-      width: 50%;
-    }
+		@media (min-width: 60rem) {
+			flex: 1 0 25%;
+			width: 25%;
+		}
+		@media (min-width: 45rem) {
+			flex: 1 0 50%;
+			width: 50%;
+		}
 		padding: 0 0.5em;
 		min-width: 15rem;
 		@media (max-width: 15rem) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -10,11 +10,11 @@ body > main {
 	}
 
 	.left, .right {
-    width: 100%;
-    @media (min-width: 45rem) {
-      flex: 1 0 50%;
-      width: 50%;
-    }
+		width: 100%;
+		@media (min-width: 45rem) {
+			flex: 1 0 50%;
+			width: 50%;
+		}
 		height: 100%;
 		float: left;
 		overflow-y: auto;
@@ -26,9 +26,9 @@ body > main {
 	}
 
 	.left {
-    @media (min-width: 45rem) {
-      border-right: 1px solid #eee;
-    }
+		@media (min-width: 45rem) {
+			border-right: 1px solid #eee;
+		}
 
 		/*h2 {
 			text-align: right;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -10,8 +10,11 @@ body > main {
 	}
 
 	.left, .right {
-		flex: 1 0 50%;
-		width: 50%;
+    width: 100%;
+    @media (min-width: 45rem) {
+      flex: 1 0 50%;
+      width: 50%;
+    }
 		height: 100%;
 		float: left;
 		overflow-y: auto;
@@ -23,7 +26,9 @@ body > main {
 	}
 
 	.left {
-		border-right: 1px solid #eee;
+    @media (min-width: 45rem) {
+      border-right: 1px solid #eee;
+    }
 
 		/*h2 {
 			text-align: right;


### PR DESCRIPTION
I'm not sure whether not supporting Safari was a conscious decision or not? But this PR removes the use of an arrow function on the homepage used to load different version of Rollup and also adds some breakpoints to fix wrapping of blocks. 

#### Previous

<img width="679" alt="screenshot 2016-09-21 09 03 25" src="https://cloud.githubusercontent.com/assets/4960622/18702583/452129ce-7fda-11e6-8998-a15e47fbaf05.png">

#### Updated

Homepage blocks now wrapping correctly

<img width="675" alt="screenshot 2016-09-21 09 03 37" src="https://cloud.githubusercontent.com/assets/4960622/18702596/5110e62a-7fda-11e6-8125-0e0cab5b390d.png">

Code Playground loading properly

<img width="741" alt="screenshot 2016-09-21 09 04 36" src="https://cloud.githubusercontent.com/assets/4960622/18702621/6f449efc-7fda-11e6-97bc-4a45d02f9582.png">
