### PR TITLE
Make input elements visible on dark UI themes

### DIFF
--- a/shared/routes/Repl/index.html
+++ b/shared/routes/Repl/index.html
@@ -72,6 +72,7 @@
 		outline: none;
 		line-height: 1;
 		color: #333;
+		background-color: inherit;
 	}
 
 	input:focus {


### PR DESCRIPTION
My GTK theme is dark, so my input boxes are white-on-black. Setting only color without also setting background-color results in dark-gray-on-black.

Alternatives include setting it to `white` or `transparent`.