### PR TITLE
Fix indentation in package.json example

### DIFF
--- a/src/guide/03-npm-run-build.md
+++ b/src/guide/03-npm-run-build.md
@@ -73,7 +73,7 @@ npm install --save-dev rollup-watch
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c",
-	"dev": "rollup -c -w"
+    "dev": "rollup -c -w"
   },
   ...
 }


### PR DESCRIPTION
Super minor, but this indentation mismatch was bothering me a bit:
![screen shot 2017-04-26 at 7 24 16 pm](https://cloud.githubusercontent.com/assets/1863540/25465264/ff4788d0-2ab5-11e7-8a34-6686e8c4c04d.png)
