### PR TITLE
Suggestion: reusing the build task in the dev-task

### DIFF
--- a/guide/en/03-npm-run-build.md
+++ b/guide/en/03-npm-run-build.md
@@ -79,4 +79,4 @@ npm install --save-dev rollup-watch
 }
 ```
 
-The command `rollup -c -w` (short for `rollup --config --watch`) runs Rollup in watch mode.
+The command `rollup -c -w` (short for `rollup --config --watch`) runs Rollup in watch mode. You could also define the `dev` command as this `npm run build -- -w` which just adds the watch flag to the build command.  

--- a/guide/en/03-npm-run-build.md
+++ b/guide/en/03-npm-run-build.md
@@ -79,4 +79,4 @@ npm install --save-dev rollup-watch
 }
 ```
 
-The command `rollup -c -w` (short for `rollup --config --watch`) runs Rollup in watch mode. You could also define the `dev` command as this `npm run build -- -w` which just adds the watch flag to the build command.  
+The command `rollup -c -w` (short for `rollup --config --watch`) runs Rollup in watch mode. You could also define the `dev` command as `npm run build -- -w` which just adds the watch flag to the build command.  


### PR DESCRIPTION
Just nitpicking here but it could be (or not :)) be a good idea to re-use the build task. Reusing it means that we ensure that the dev task is actually the doing the same as the build, only under watch. 

Could be worth pointing out, I thought. 

Awesome guide!