### PR TITLE
babel-preset-latest is deprecated

### DIFF
--- a/guide/en/05-tools.md
+++ b/guide/en/05-tools.md
@@ -181,7 +181,7 @@ Secondly, we're using the `external-helpers` plugin, which allows Rollup to incl
 
 Thirdly, we're putting our `.babelrc` file in `src`, rather than the project root. This allows us to have a different `.babelrc` for things like tests, if we need that later – it's generally a good idea to have separate configuration for separate tasks.
 
-Now, before we run rollup, we need to install the `latest` preset and the `external-helpers` plugin:
+Now, before we run rollup, we need to install the [`env`](https://babeljs.io/docs/plugins/preset-env/) preset and the `external-helpers` plugin:
 
 ```bash
 npm i -D babel-preset-env babel-plugin-external-helpers

--- a/guide/en/05-tools.md
+++ b/guide/en/05-tools.md
@@ -167,10 +167,8 @@ Before Babel will actually compile your code, it needs to be configured. Create 
 ```js
 {
   "presets": [
-    ["latest", {
-      "es2015": {
-        "modules": false
-      }
+    ["env", {
+      "modules": false
     }]
   ],
   "plugins": ["external-helpers"]
@@ -186,7 +184,7 @@ Thirdly, we're putting our `.babelrc` file in `src`, rather than the project roo
 Now, before we run rollup, we need to install the `latest` preset and the `external-helpers` plugin:
 
 ```bash
-npm i -D babel-preset-latest babel-plugin-external-helpers
+npm i -D babel-preset-env babel-plugin-external-helpers
 ```
 
 Running Rollup now will create a bundle... except we're not actually using any ES2015 features. Let's change that. Edit `src/main.js`:


### PR DESCRIPTION
Installing `babel-preset-latest` gives a warning that says:

> (...) instead of making more yearly presets, Babel now has a better preset that we recommend you use instead: `npm install babel-preset-env --save-dev`. preset-env without options will compile ES2015+ down to ES5 just like using all the presets together and thus is more future proof. (...)

There's also a link to this page which explains how to use it: http://babeljs.io/env