### PR TITLE
Add package.json content to tutorial

### DIFF
--- a/guide/en/02-tutorial.md
+++ b/guide/en/02-tutorial.md
@@ -132,6 +132,18 @@ For that, we use *plugins*, which change the behaviour of Rollup at key points i
 
 For this tutorial, we'll use [rollup-plugin-json](https://github.com/rollup/rollup-plugin-json), which allows Rollup to import data from a JSON file.
 
+Create a file in the project root called `package.json`, and add the following content:
+
+```json
+{
+  "name": "rollup-tutorial",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "rollup -c"
+  }
+}
+```
+
 Install rollup-plugin-json as a development dependency:
 
 ```bash


### PR DESCRIPTION
I've added missing mention of `package.json` and it's content to make a tutorial instructions work step by step.
If you follow the tutorial and run`npm run build` – it doesn't work, because `package.json` file doesn't exist.