### PR TITLE
added dynamic import section

### DIFF
--- a/guide/en/06-es-module-syntax.md
+++ b/guide/en/06-es-module-syntax.md
@@ -53,7 +53,7 @@ This is useful for polyfills, or when the primary purpose of the imported code i
 
 #### Dynamic Import
 
-Import modules using the [dynamic import API](https://github.com/tc39/proposal-dynamic-import#import). This API is experimental and available under the **experimentalDynamicImport** flag.
+Import modules using the [dynamic import API](https://github.com/tc39/proposal-dynamic-import#import). This API is experimental and available under the `experimentalDynamicImport` flag.
 
 ```js
 import('./modules.js').then(({ default: DefaultExport, NamedExport })=> {
@@ -61,7 +61,7 @@ import('./modules.js').then(({ default: DefaultExport, NamedExport })=> {
 })
 ```
 
-This is useful for code-splitting applications and using modules on-the-fly. Note that dynamic imports are not available when targeting ECMAScript 2015 modules.
+This is useful for code-splitting applications and using modules on-the-fly.
 
 ### Exporting
 

--- a/guide/en/06-es-module-syntax.md
+++ b/guide/en/06-es-module-syntax.md
@@ -51,6 +51,17 @@ import './module.js';
 
 This is useful for polyfills, or when the primary purpose of the imported code is to muck about with prototypes.
 
+#### Dynamic Import
+
+Import modules using the [dynamic import API](https://github.com/tc39/proposal-dynamic-import#import). This API is experimental and available under the **experimentalDynamicImport** flag.
+
+```js
+import('./modules.js').then(({ default: DefaultExport, NamedExport })=> {
+  // do something with modules.
+})
+```
+
+This is useful for code-splitting applications and using modules on-the-fly. Note that dynamic imports are not available when targeting ECMAScript 2015 modules.
 
 ### Exporting
 


### PR DESCRIPTION
Provides documentation to address [#1807](https://github.com/rollup/rollup/issues/1807).

Note that [this issue](https://github.com/rollup/rollup/issues/1807#issuecomment-359962886) persisted, and I was not able to see my local changes on the site using `npm run dev`.

I looks like no matter what I did to the files in `guide/en/`, running that script always yielded a bundle with hash `585cafe4acc92fecd86a`. I tried deleting the `.sapper` directory before retrying the command, but that did not work.