### PR TITLE
Update FAQs with regard to code splitting

### DIFF
--- a/guide/en/01-faqs.md
+++ b/guide/en/01-faqs.md
@@ -16,7 +16,7 @@ Rollup strives to implement the specification for ES modules, not necessarily th
 
 #### Is Rollup meant for building libraries or applications?
 
-Rollup is already used by many major JavaScript libraries, and can also be used to build the vast majority of applications. However if you want to use code-splitting or dynamic imports with older browsers, you will need an additional runtime to handle loading missing chunks. We recommend using [SystemJS](https://github.com/systemjs/systemjs) as it integrates nicely with rollup and is capable of properly handling all ES module features such as live bindings and circular references.
+Rollup is already used by many major JavaScript libraries, and can also be used to build the vast majority of applications. However if you want to use code-splitting or dynamic imports with older browsers, you will need an additional runtime to handle loading missing chunks. We recommend using [SystemJS](https://github.com/systemjs/systemjs) as it integrates nicely with Rollup and is capable of properly handling all ES module features such as live bindings and circular references.
 
 #### Who made the Rollup logo? It's lovely.
 

--- a/guide/en/01-faqs.md
+++ b/guide/en/01-faqs.md
@@ -16,7 +16,7 @@ Rollup strives to implement the specification for ES modules, not necessarily th
 
 #### Is Rollup meant for building libraries or applications?
 
-Rollup is already used by many major JavaScript libraries, and can also be used to build the vast majority of applications. However, Rollup doesn't yet support a few specific advanced features that can sometimes be useful when building applications, most notably code splitting and [dynamic imports at runtime](https://github.com/tc39/proposal-dynamic-import). If your project needs either of those, you may be better off with [Webpack](https://webpack.js.org/).
+Rollup is already used by many major JavaScript libraries, and can also be used to build the vast majority of applications. However if you want to use code-splitting or dynamic imports with older browsers, you will need an additional runtime to handle loading missing chunks. We recommend using [SystemJS](https://github.com/systemjs/systemjs) as it integrates nicely with rollup and is capable of properly handling all ES module features such as live bindings and circular references.
 
 #### Who made the Rollup logo? It's lovely.
 


### PR DESCRIPTION
By popular demand on Twitter 😄
Replaces the outdated FAQ section about using Webpack for code-splitting with a recommendation to use SystemJS. Might be slightly controversial so feedback is welcome.