### PR TITLE
Add code splitting, dynamic import and acorn options

### DIFF
--- a/guide/en/03-command-line-reference.md
+++ b/guide/en/03-command-line-reference.md
@@ -25,15 +25,21 @@ export default { // can be an array (for multiple inputs)
 
   // danger zone
   acorn,
+  acornInjectPlugins,
   treeshake,
   context,
   moduleContext,
   legacy,
+  
+  // experimental
+  experimentalDynamicImport,
+  experimentalCodeSplitting,
 
   output: {  // required (can be an array, for multiple outputs)
     // core output options
-    file,    // required
     format,  // required
+    file,
+    dir,
     name,
     globals,
 
@@ -65,7 +71,7 @@ export default { // can be an array (for multiple inputs)
 };
 ```
 
-You can export an **array** from your config file to build bundles from several different inputs at once, even in watch mode. To build different bundles with the same input, you supply an array of output options for each input:
+You can export an **array** from your config file to build bundles from several different unrelated inputs at once, even in watch mode. To build different bundles with the same input, you supply an array of output options for each input:
 
 ```javascript
 // rollup.config.js (building more than one bundle)
@@ -90,7 +96,7 @@ export default [{
 }];
 ```
 
-Want to read your config async? No problem! Rollup can also handle a `Promise` which resolves to an object or an array.
+If you want to create your config asynchronously, Rollup can also handle a `Promise` which resolves to an object or an array.
 
 ```javascript
 // rollup.config.js

--- a/guide/en/04-javascript-api.md
+++ b/guide/en/04-javascript-api.md
@@ -51,10 +51,15 @@ const inputOptions = {
 
   // danger zone
   acorn,
+  acornInjectPlugins,
   treeshake,
   context,
   moduleContext,
-  legacy
+  legacy,
+          
+  // experimental
+  experimentalDynamicImport,
+  experimentalCodeSplitting
 };
 ```
 
@@ -66,8 +71,9 @@ The `outputOptions` object can contain the following properties (see the [big li
 ```js
 const outputOptions = {
   // core options
-  file,   // required with bundle.write
   format, // required
+  file,
+  dir,
   name,
   globals,
 

--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -6,7 +6,8 @@ title: Big list of options
 
 #### input *`-i`/`--input`*
 
-`String`|`String[]` The bundle's entry point (e.g. your `main.js` or `app.js` or `index.js`). If you enable `experimentalCodeSplitting`, you can provide an array of entry points which will be bundled to separate chunks.
+`String`/ 
+`String[]` The bundle's entry point (e.g. your `main.js` or `app.js` or `index.js`). If you enable `experimentalCodeSplitting`, you can provide an array of entry points which will be bundled to separate chunks.
 
 #### file *`-o`/`--output.file`*
 
@@ -303,11 +304,11 @@ const illegalAccess = foo.quux.tooDeep;
 
 #### acorn
 
-Any options that should be passed through to Acorn, such as `allowReserved: true`.
+Any options that should be passed through to Acorn, such as `allowReserved: true`. Cf. the [Acorn documentation](https://github.com/acornjs/acorn/blob/master/README.md#main-parser) for more available options.
 
 #### acornInjectPlugins
 
-An array of plugins to passed to `acorn`. To e.g. use async iteration, you can specify
+An array of plugins to be injected into Acorn. In order to use a plugin, you need to pass its inject function here and enable it via the `acorn.plugins` option. For instance, to use async iteration, you can specify
 ```javascript
 import acornAsyncIteration from 'acorn-async-iteration/inject';
 
@@ -427,14 +428,15 @@ These options reflect new features that have not yet been fully finalized. Speci
 ```javascript
 import('./my-module.js').then(moduleNamespace => console.log(moduleNamespace.foo));
 ```
-When used without `experimentalCodeSplitting`, statically resolvable dynamic imports will automatically be inlined into your bundle. Also enables the `resolveDynamicImport` plugin hook.
+When used without `experimentalCodeSplitting`, statically resolvable dynamic imports will be automatically inlined into your bundle. Also enables the `resolveDynamicImport` plugin hook.
 
 #### experimentalCodeSplitting *`--experimentalCodeSplitting`*
-`true` or `false` (defaults to `false`) – enables you to specify multiple entry points. If this option is enabled AND `input` is an array:
-* You must specify `output.dir` instead of `output.file`
-* Filenames of generated chunks correspond to the filenames of the entry points
-* Additional shared chunks may be generated which are imported by your entry points to avoid code duplication
-* If `experimentalDynamicImport` is enabled as well, statically resolvable dynamic imports will not be inlined but instead generate new chunks
+`true` or `false` (defaults to `false`) – enables you to specify multiple entry points. If this option is enabled, `input` can be set to an array of entry points to be built into the folder at the provided `output.dir`.
+* Filenames of generated chunks in the `output.dir` folder correspond to the entry point filenames.
+* Shared chunks are generated automatically to avoid code duplication between chunks.
+* Enable the `experimentalDynamicImport` flag to generate new chunks for dynamic imports as well.
+
+`output.dir` and input as an array must both be provided for code splitting to work, the `output.file` option is not compatible with code splitting workflows.
 
 ### Watch options
 

--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -6,11 +6,15 @@ title: Big list of options
 
 #### input *`-i`/`--input`*
 
-`String` The bundle's entry point (e.g. your `main.js` or `app.js` or `index.js`)
+`String`|`String[]` The bundle's entry point (e.g. your `main.js` or `app.js` or `index.js`). If you enable `experimentalCodeSplitting`, you can provide an array of entry points which will be bundled to separate chunks.
 
 #### file *`-o`/`--output.file`*
 
-`String` The file to write to. Will also be used to generate sourcemaps, if applicable
+`String` The file to write to. Will also be used to generate sourcemaps, if applicable. If `experimentalCodeSplitting` is enabled and `input` is an array, you must specify `dir` instead of `file`.
+
+#### dir * `--output.dir`*
+
+`String` The directory in which all generated chunks are placed. Only used when `experimentalCodeSplitting` is enabled and `input` is an array in which case this option replaces `file`.
 
 #### format *`-f`/`--output.format`*
 
@@ -21,6 +25,7 @@ title: Big list of options
 * `es` – Keep the bundle as an ES module file
 * `iife` – A self-executing function, suitable for inclusion as a `<script>` tag. (If you want to create a bundle for your application, you probably want to use this, because it leads to smaller file sizes.)
 * `umd` – Universal Module Definition, works as `amd`, `cjs` and `iife` all in one
+* `system` – Native format of the SystemJS loader
 
 #### name *`-n`/`--name`*
 
@@ -300,6 +305,25 @@ const illegalAccess = foo.quux.tooDeep;
 
 Any options that should be passed through to Acorn, such as `allowReserved: true`.
 
+#### acornInjectPlugins
+
+An array of plugins to passed to `acorn`. To e.g. use async iteration, you can specify
+```javascript
+import acornAsyncIteration from 'acorn-async-iteration/inject';
+
+export default {
+    // … other options …
+    acorn: {
+        plugins: { asyncIteration: true }
+    },
+    acornInjectPlugins: [
+        acornAsyncIteration
+    ]
+};
+```
+
+in your rollup configuration.
+
 #### context
 
 By default, the context of a module – i.e., the value of `this` at the top level – is `undefined`. In rare cases you might need to change this to something else, like `'window'`.
@@ -394,6 +418,23 @@ export default {
 
 `true` or `false` (defaults to `true`) – wether to `Object.freeze()` namespace import objects (i.e. `import * as namespaceImportObject from...`) that are accessed dynamically.
 
+### Experimental options
+
+These options reflect new features that have not yet been fully finalized. Specific behaviour and usage may therefore be subject to change.
+
+#### experimentalDynamicImport *`--experimentalDynamicImport`*
+`true` or `false` (defaults to `false`) – adds the necessary acorn plugin to enable parsing dynamic imports, e.g.
+```javascript
+import('./my-module.js').then(moduleNamespace => console.log(moduleNamespace.foo));
+```
+When used without `experimentalCodeSplitting`, statically resolvable dynamic imports will automatically be inlined into your bundle. Also enables the `resolveDynamicImport` plugin hook.
+
+#### experimentalCodeSplitting *`--experimentalCodeSplitting`*
+`true` or `false` (defaults to `false`) – enables you to specify multiple entry points. If this option is enabled AND `input` is an array:
+* You must specify `output.dir` instead of `output.file`
+* Filenames of generated chunks correspond to the filenames of the entry points
+* Additional shared chunks may be generated which are imported by your entry points to avoid code duplication
+* If `experimentalDynamicImport` is enabled as well, statically resolvable dynamic imports will not be inlined but instead generate new chunks
 
 ### Watch options
 


### PR DESCRIPTION
This should update the "big list of options" to contain the new experimental options as well as the `acornInjectPlugings` option. @guybedford @stasm please have a look if everything I wrote is correct.