### PR TITLE
Improve comments in examples

### DIFF
--- a/examples/00/modules/main.js
+++ b/examples/00/modules/main.js
@@ -1,2 +1,4 @@
+/* TREE-SHAKING */
 import { cube } from './maths.js';
+
 console.log( cube( 5 ) ); // 125

--- a/examples/00/modules/maths.js
+++ b/examples/00/modules/maths.js
@@ -1,3 +1,5 @@
+// maths.js
+
 // This function isn't used anywhere, so
 // Rollup excludes it from the bundle...
 export function square ( x ) {

--- a/examples/01/modules/main.js
+++ b/examples/01/modules/main.js
@@ -1,7 +1,8 @@
+/* DEFAULT EXPORTS
+   Default exports from the 'entry module' are
+   exported from the bundle */
 import answer from './answer.js';
 
-// Default exports from the 'entry module' are
-// exported from the bundle
 export default function () {
 	console.log( 'the answer is ' + answer );
 }

--- a/examples/02/modules/main.js
+++ b/examples/02/modules/main.js
@@ -1,5 +1,6 @@
-// There are many ways to export bindings
-// from an ES2015 module
+/* NAMED EXPORTS
+   There are many ways to export bindings
+   from an ES2015 module */
 export var foo = 1;
 
 export function bar () {

--- a/examples/03/modules/main.js
+++ b/examples/03/modules/main.js
@@ -1,5 +1,6 @@
-// You can import external modules into your bundle –
-// it doesn't matter if they're ES2015 or legacy
+/* EXTERNAL IMPORTS
+   You can import external modules into your bundle –
+   it doesn't matter if they're ES2015 or legacy */
 import $ from 'jquery';
 
 $( 'body' ).html( '<h1>Hello world!</h1>' );

--- a/examples/04/modules/main.js
+++ b/examples/04/modules/main.js
@@ -1,5 +1,6 @@
-// ES6 modules let you import all of another module's
-// exports as a namespace...
+/* STATIC NAMESPACES
+   ES6 modules let you import all of another module's
+   exports as a namespace... */
 import * as assert from './assert';
 
 // ...but we can statically resolve this to the

--- a/examples/05/modules/main.js
+++ b/examples/05/modules/main.js
@@ -1,9 +1,10 @@
+/* DYNAMIC NAMESPACES
+   In some cases, you don't know which exports will
+   be accessed until you actually run the code. In
+   these cases, Rollup creates a namespace object
+   for dynamic lookup */
 import * as constants from './constants';
 
-// In some cases, you don't know which exports will
-// be accessed until you actually run the code. In
-// these cases, Rollup creates a namespace object
-// for dynamic lookup
 Object.keys( constants ).forEach( key => {
 	console.log( `The value of ${key} is ${constants[key]}` );
 });


### PR DESCRIPTION
to better work with the new "only first line comments are headers" rule introduced in rollup v0.56.0