### PR TITLE
Updates for 0.60 api changes

### DIFF
--- a/guide/en/02-tutorial.md
+++ b/guide/en/02-tutorial.md
@@ -211,7 +211,7 @@ export default function () {
 We can then pass both entry points to the rollup build, and instead of an output file we set a folder to output to with the `--dir` option (also passing the experimental flags):
 
 ```bash
-rollup src/main.js src/main2.js -f cjs --dir dist --experimentalCodeSplitting --experimentalDynamicImport
+rollup src/main.js src/main2.js -f cjs --dir dist --experimentalCodeSplitting
 ```
 
 Either built entry point can then be run in NodeJS without duplicating any code between the modules:
@@ -225,7 +225,7 @@ You can build the same code for the browser, for native ES modules, an AMD loade
 For example, with `-f es` for native modules:
 
 ```bash
-rollup src/main.js src/main2.js -f es --dir dist --experimentalCodeSplitting --experimentalDynamicImport
+rollup src/main.js src/main2.js -f es --dir dist --experimentalCodeSplitting
 ```
 
 ```html
@@ -239,7 +239,7 @@ rollup src/main.js src/main2.js -f es --dir dist --experimentalCodeSplitting --e
 Or alternatively, for SystemJS with `-f system`:
 
 ```bash
-rollup src/main.js src/main2.js -f system --dir dist --experimentalCodeSplitting --experimentalDynamicImport
+rollup src/main.js src/main2.js -f system --dir dist --experimentalCodeSplitting
 ```
 
 install SystemJS via

--- a/guide/en/03-command-line-reference.md
+++ b/guide/en/03-command-line-reference.md
@@ -33,7 +33,6 @@ export default { // can be an array (for multiple inputs)
   
   // experimental
   experimentalCodeSplitting,
-  experimentalDynamicImport,
   manualChunks,
   optimizeChunks,
   chunkGroupingSize,
@@ -67,8 +66,9 @@ export default { // can be an array (for multiple inputs)
     namespaceToStringTag
     
     // experimental
-    entryNames,
-    chunkNames
+    entryFileNames,
+    chunkFileNames,
+    assetFileNames
   },
 
   watch: {

--- a/guide/en/04-javascript-api.md
+++ b/guide/en/04-javascript-api.md
@@ -61,8 +61,7 @@ const inputOptions = {
   experimentalCodeSplitting,
   manualChunks,
   optimizeChunks,
-  chunkGroupingSize,
-  experimentalDynamicImport
+  chunkGroupingSize
 };
 ```
 
@@ -101,8 +100,9 @@ const outputOptions = {
   namespaceToStringTag,
   
   // experimental
-  entryNames,
-  chunkNames
+  entryFileNames,
+  chunkFileNames,
+  assetFileNames
 };
 ```
 

--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -462,13 +462,17 @@ When used without `experimentalCodeSplitting`, statically resolvable dynamic imp
 
 `output.dir` and input as an array must both be provided for code splitting to work, the `output.file` option is not compatible with code splitting workflows.
 
-#### output.entryNames *`--entryNames`*
+#### output.entryFileNames *`--entryFileNames`*
 
 `String` the pattern to use for naming entry point output files within `dir` when code splitting. Defaults to `"[alias].js"`.
 
-#### output.chunkNames *`--chunkNames`*
+#### output.chunkFileNames *`--chunkFileNames`*
 
 `String` the pattern to use for naming shared chunks created when code-splitting. Defaults to `"[alias]-[hash].js"`.
+
+#### output.assetFileNames *`--assetFileNames`*
+
+`String` the pattern to use for naming custom emitted assets to include in the build output when code-splitting. Defaults to `"assets/[name]-[hash][extname]"`.
 
 #### manualChunks *`--manualChunks`*
 


### PR DESCRIPTION
Specifically `experimentalDynamicImport` is no longer needed, `chunkNames` and `entryNames` are now `chunkFileNames` and `entryFileNames`, and `assetFileNames` is included.

There's still no single place explaining how this whole asset system works... maybe I'll see if I can pad out the plugin wiki a little further on this too.

//cc @lukastaegert 