### PR TITLE
Standardize examples in quick start section

### DIFF
--- a/guide/en/00-introduction.md
+++ b/guide/en/00-introduction.md
@@ -20,21 +20,21 @@ For browsers:
 
 ```bash
 # compile to a <script> containing a self-executing function ('iife')
-$ rollup main.js --o bundle.js --f iife
+$ rollup main.js --file bundle.js --format iife
 ```
 
 For Node.js:
 
 ```bash
 # compile to a CommonJS module ('cjs')
-$ rollup main.js --o bundle.js --f cjs
+$ rollup main.js --file bundle.js --format cjs
 ```
 
 For both browsers and Node.js:
 
 ```bash
 # UMD format requires a bundle name
-$ rollup main.js --o bundle.js -f umd --name "myBundle"
+$ rollup main.js --file bundle.js --format umd --name "myBundle"
 ```
 
 ### Why

--- a/guide/sk/00-introduction.md
+++ b/guide/sk/00-introduction.md
@@ -18,21 +18,21 @@ Pre prehliadače:
 
 ```bash
 # kompilovať pre využitie v <script> ako samo-spúšťaciu funkciu
-$ rollup main.js --format iife --output bundle.js
+$ rollup main.js --file bundle.js --format iife
 ```
 
 Pre Node.js:
 
 ```bash
 # kompilovať ako CommonJS modul
-$ rollup main.js --format cjs --output bundle.js
+$ rollup main.js --file bundle.js --format cjs
 ```
 
 Pre prehliadače a Node.js:
 
 ```bash
 # formát UMD vyžaduje názov balíčka
-$ rollup main.js --format umd --name "myBundle" --output bundle.js
+$ rollup main.js --file bundle.js --format umd --name "myBundle"
 ```
 
 ### Prečo

--- a/guide/zh/00-introduction.md
+++ b/guide/zh/00-introduction.md
@@ -20,21 +20,21 @@ Rollup 是一个 JavaScript 模块打包器，可以将小块代码编译成大�
 
 ```bash
 # compile to a <script> containing a self-executing function ('iife')
-$ rollup main.js --o bundle.js --f iife
+$ rollup main.js --file bundle.js --format iife
 ```
 
 对于 Node.js:
 
 ```bash
 # compile to a CommonJS module ('cjs')
-$ rollup main.js --o bundle.js --f cjs
+$ rollup main.js --file bundle.js --format cjs
 ```
 
 对于浏览器和 Node.js:
 
 ```bash
 # UMD format requires a bundle name
-$ rollup main.js --o bundle.js -f umd --name "myBundle"
+$ rollup main.js --file bundle.js --format umd --name "myBundle"
 ```
 
 ### 为什么(Why)


### PR DESCRIPTION
Standardizes the three examples in the [Quick start](https://rollupjs.org/guide/en#quick-start) section.

I’d argue that long options are more helpful (especially in the quick start section), however, if you’d prefer short options, just let me know.