### PR TITLE
Don’t syntax-highlight command-line flags

### DIFF
--- a/guide/en/03-command-line-reference.md
+++ b/guide/en/03-command-line-reference.md
@@ -160,7 +160,7 @@ If you now run `rollup --config --configDebug`, the debug configuration will be 
 
 Many options have command line equivalents. Any arguments passed here will override the config file, if you're using one. See the [big list of options](#big-list-of-options) for details.
 
-```
+```text
 -c, --config                Use this config file (if argument is used but value
                               is unspecified, defaults to rollup.config.js)
 -i, --input                 Input (alternative to <entry file>)

--- a/guide/zh/03-command-line-reference.md
+++ b/guide/zh/03-command-line-reference.md
@@ -73,7 +73,7 @@ $ rollup --config my.config.js
 
 配置文件中的许多选项和命令行的参数是等价的。如果你使用这里的参数，那么将重写配置文件。想了解更多的话，仔细查阅这个[包办大量选项的清单](#big-list-of-options)
 
-```bash
+```text
 -i, --input                 要打包的文件（必须）
 -o, --output.file           输出的文件 (如果没有这个参数，则直接输出到控制台)
 -f, --output.format [es]    输出的文件类型 (amd, cjs, es, iife, umd)

--- a/routes/api/guide/_data.js
+++ b/routes/api/guide/_data.js
@@ -3,6 +3,9 @@ import path from 'path';
 import marked from 'marked';
 import hljs from 'highlight.js';
 
+// Register dummy language for plain text code blocks.
+hljs.registerLanguage('text', () => ({}));
+
 export default fs.readdirSync('guide')
 	.filter(dir => {
 		return fs.statSync(`guide/${dir}`).isDirectory();


### PR DESCRIPTION
Treat the code block in the [Command line flags](https://rollupjs.org/guide/en#command-line-flags) section as plain text. Currently, keywords such as `if` and `for` are highlighted and the apostrophe in `Don't` denotes a Bash string.

Before:

![Before](https://user-images.githubusercontent.com/652793/41203119-298e9fb0-6cd3-11e8-85da-0297e724033c.png)

After:

![After](https://user-images.githubusercontent.com/652793/41203122-2be412b8-6cd3-11e8-8a7b-f3c1a2861cd7.png)