### PR TITLE
[alias] isn't valid for chunkFileNames

### DIFF
--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -468,7 +468,7 @@ When used without `experimentalCodeSplitting`, statically resolvable dynamic imp
 
 #### output.chunkFileNames *`--chunkFileNames`*
 
-`String` the pattern to use for naming shared chunks created when code-splitting. Defaults to `"[alias]-[hash].js"`.
+`String` the pattern to use for naming shared chunks created when code-splitting. Defaults to `"[name]-[hash].js"`.
 
 #### output.assetFileNames *`--assetFileNames`*
 


### PR DESCRIPTION
So use `[name]` instead, which is valid and the actual default.

https://github.com/rollup/rollup/blob/8112edcaaf6ae24b1fce02b192bd4410de73a16c/src/rollup/index.ts#L319