### PR TITLE
docs: fix entryFileNames example to use [name]

### DIFF
--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -464,7 +464,7 @@ When used without `experimentalCodeSplitting`, statically resolvable dynamic imp
 
 #### output.entryFileNames *`--entryFileNames`*
 
-`String` the pattern to use for naming entry point output files within `dir` when code splitting. Defaults to `"[alias].js"`.
+`String` the pattern to use for naming entry point output files within `dir` when code splitting. Defaults to `"[name].js"`.
 
 #### output.chunkFileNames *`--chunkFileNames`*
 


### PR DESCRIPTION
Since `[alias]` isn't valid.

As requested by @guybedford in https://github.com/rollup/rollupjs.org/pull/140