### PR TITLE
Replace "es" format by "esm" everywhere

### DIFF
--- a/guide/en/02-tutorial.md
+++ b/guide/en/02-tutorial.md
@@ -222,10 +222,10 @@ node -e "require('./dist/main2.js')()"
 
 You can build the same code for the browser, for native ES modules, an AMD loader or SystemJS.
 
-For example, with `-f es` for native modules:
+For example, with `-f esm` for native modules:
 
 ```bash
-rollup src/main.js src/main2.js -f es --dir dist --experimentalCodeSplitting
+rollup src/main.js src/main2.js -f esm --dir dist --experimentalCodeSplitting
 ```
 
 ```html

--- a/guide/en/03-command-line-reference.md
+++ b/guide/en/03-command-line-reference.md
@@ -99,7 +99,7 @@ export default [{
     },
     {
       file: 'dist/bundle-b2.js',
-      format: 'es'
+      format: 'esm'
     }
   ]
 }];
@@ -165,7 +165,7 @@ Many options have command line equivalents. Any arguments passed here will overr
                               is unspecified, defaults to rollup.config.js)
 -i, --input                 Input (alternative to <entry file>)
 -o, --file <output>         Output (if absent, prints to stdout)
--f, --format [es]           Type of output (amd, cjs, es, iife, umd)
+-f, --format [esm]          Type of output (amd, cjs, esm, iife, umd)
 -e, --external              Comma-separate list of module IDs to exclude
 -g, --globals               Comma-separate list of `module ID:Global` pairs
                               Any module IDs defined here are added to external

--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -22,7 +22,7 @@ title: Big list of options
 
 * `amd` – Asynchronous Module Definition, used with module loaders like RequireJS
 * `cjs` – CommonJS, suitable for Node and Browserify/Webpack
-* `es` – Keep the bundle as an ES module file
+* `esm` – Keep the bundle as an ES module file
 * `iife` – A self-executing function, suitable for inclusion as a `<script>` tag. (If you want to create a bundle for your application, you probably want to use this, because it leads to smaller file sizes.)
 * `umd` – Universal Module Definition, works as `amd`, `cjs` and `iife` all in one
 * `system` – Native format of the SystemJS loader


### PR DESCRIPTION
Definitely an important first step in deprecating "es" 😉