### PR TITLE
Remove "legacy" option

### DIFF
--- a/guide/en/03-command-line-reference.md
+++ b/guide/en/03-command-line-reference.md
@@ -62,8 +62,7 @@ export default { // can be an array (for multiple inputs)
     indent,
     strict,
     freeze,
-    legacy,
-    namespaceToStringTag
+    namespaceToStringTag,
     
     // experimental
     entryFileNames,
@@ -171,7 +170,6 @@ Many options have command line equivalents. Any arguments passed here will overr
                               Any module IDs defined here are added to external
 -n, --name                  Name for UMD export
 -m, --sourcemap             Generate sourcemap (`-m inline` for inline map)
--l, --legacy                Support IE8
 --amd.id                    ID for AMD module (default is anonymous)
 --amd.define                Function to use in place of `define`
 --no-strict                 Don't emit a `"use strict";` in the generated modules.

--- a/guide/en/04-javascript-api.md
+++ b/guide/en/04-javascript-api.md
@@ -96,7 +96,6 @@ const outputOptions = {
   indent,
   strict,
   freeze,
-  legacy,
   namespaceToStringTag,
   
   // experimental

--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -344,10 +344,6 @@ in your rollup configuration.
 
 Same as `options.context`, but per-module – can either be an object of `id: context` pairs, or an `id => context` function.
 
-#### output.legacy *`-l`/`--legacy`*
-
-`true` or `false` (defaults to `false`) – adds support for very old environments like IE8 by stripping out more modern code that might not work reliably, at the cost of deviating slightly from the precise specifications required of ES6 module environments.
-
 #### output.exports *`--exports`*
 
 `String` What export mode to use. Defaults to `auto`, which guesses your intentions based on what the `entry` module exports:


### PR DESCRIPTION
This has already been removed from Rollup