### PR TITLE
Code blocks need to be preceded and followed by blank lines

### DIFF
--- a/guide/en/03-command-line-reference.md
+++ b/guide/en/03-command-line-reference.md
@@ -208,8 +208,8 @@ Pass additional settings to the config file via `process.ENV`.
 
 ```sh
 rollup -c --environment INCLUDE_DEPS,BUILD:production
-
 ```
+
 will set `process.env.INCLUDE_DEPS === 'true'` and `process.env.BUILD === 'production'`. You can use this option several times. In that case, subsequently set variables will overwrite previous definitions. This enables you for instance to overwrite environment variables in package.json scripts:
 
 ```json
@@ -222,6 +222,7 @@ will set `process.env.INCLUDE_DEPS === 'true'` and `process.env.BUILD === 'produ
 ```
 
 If you call this script via
+
 ```bash
 npm run build -- --environment BUILD:development
 ```

--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -320,6 +320,7 @@ Any options that should be passed through to Acorn, such as `allowReserved: true
 #### acornInjectPlugins
 
 An array of plugins to be injected into Acorn. In order to use a plugin, you need to pass its inject function here and enable it via the `acorn.plugins` option. For instance, to use async iteration, you can specify
+
 ```javascript
 import acornAsyncIteration from 'acorn-async-iteration/inject';
 
@@ -445,9 +446,12 @@ These options reflect new features that have not yet been fully finalized. Speci
 
 #### experimentalDynamicImport *`--experimentalDynamicImport`*
 `true` or `false` (defaults to `false`) – adds the necessary acorn plugin to enable parsing dynamic imports, e.g.
+
 ```javascript
-import('./my-module.js').then(moduleNamespace => console.log(moduleNamespace.foo));
+import('./my-module.js')
+  .then(moduleNamespace => console.log(moduleNamespace.foo));
 ```
+
 When used without `experimentalCodeSplitting`, statically resolvable dynamic imports will be automatically inlined into your bundle. Also enables the `resolveDynamicImport` plugin hook.
 
 #### experimentalCodeSplitting *`--experimentalCodeSplitting`*


### PR DESCRIPTION
otherwise they will not be printed correctly. Resolves rollup/rollup#2361