### PR TITLE
fix(guide): set proper link to anchor

### DIFF
--- a/guide/en/03-command-line-reference.md
+++ b/guide/en/03-command-line-reference.md
@@ -24,7 +24,7 @@ module.exports = {
 
 It may be pertinent if you want to use the config file not only from the command line, but also from your custom scripts programmatically.
 
-Consult the [big list of options](#big-list-of-options) for details on each option you can include in your config file.
+Consult the [big list of options](guide/en#big-list-of-options) for details on each option you can include in your config file.
 
 ```javascript
 // rollup.config.js
@@ -171,7 +171,7 @@ If you now run `rollup --config --configDebug`, the debug configuration will be 
 
 ### Command line flags
 
-Many options have command line equivalents. Any arguments passed here will override the config file, if you're using one. See the [big list of options](#big-list-of-options) for details.
+Many options have command line equivalents. Any arguments passed here will override the config file, if you're using one. See the [big list of options](guide/en#big-list-of-options) for details.
 
 ```text
 -c, --config                Use this config file (if argument is used but value

--- a/guide/en/04-javascript-api.md
+++ b/guide/en/04-javascript-api.md
@@ -36,7 +36,7 @@ build();
 
 #### inputOptions
 
-The `inputOptions` object can contain the following properties (see the [big list of options](#big-list-of-options) for full details on these):
+The `inputOptions` object can contain the following properties (see the [big list of options](guide/en#big-list-of-options) for full details on these):
 
 ```js
 const inputOptions = {
@@ -68,7 +68,7 @@ const inputOptions = {
 
 #### outputOptions
 
-The `outputOptions` object can contain the following properties (see the [big list of options](#big-list-of-options) for full details on these):
+The `outputOptions` object can contain the following properties (see the [big list of options](guide/en#big-list-of-options) for full details on these):
 
 ```js
 const outputOptions = {
@@ -147,7 +147,7 @@ const watchOptions = {
 };
 ```
 
-See above for details on `inputOptions` and `outputOptions`, or consult the [big list of options](#big-list-of-options) for info on `chokidar`, `include` and `exclude`.
+See above for details on `inputOptions` and `outputOptions`, or consult the [big list of options](guide/en#big-list-of-options) for info on `chokidar`, `include` and `exclude`.
 
 
 ### TypeScript Declarations

--- a/guide/zh/03-command-line-reference.md
+++ b/guide/zh/03-command-line-reference.md
@@ -10,7 +10,7 @@ Rollup的配置文件是可选的，但是使用配置文件的作用很强大�
 
 配置文件是一个ES6模块，它对外暴露一个对象，这个对象包含了一些Rollup需要的一些选项。通常，我们把这个配置文件叫做`rollup.config.js`，它通常位于项目的根目录
 
-仔细查阅这个[包办大量选项的清单](#big-list-of-options)，你可以根据你自己的需要把它配置到你的配置文件中
+仔细查阅这个[包办大量选项的清单](guide/zh#big-list-of-options)，你可以根据你自己的需要把它配置到你的配置文件中
 
 ```javascript
 // rollup.config.js
@@ -71,7 +71,7 @@ $ rollup --config my.config.js
 
 ### 命令行的参数(Command line flags)
 
-配置文件中的许多选项和命令行的参数是等价的。如果你使用这里的参数，那么将重写配置文件。想了解更多的话，仔细查阅这个[包办大量选项的清单](#big-list-of-options)
+配置文件中的许多选项和命令行的参数是等价的。如果你使用这里的参数，那么将重写配置文件。想了解更多的话，仔细查阅这个[包办大量选项的清单](guide/zh#big-list-of-options)
 
 ```text
 -i, --input                 要打包的文件（必须）

--- a/guide/zh/04-javascript-api.md
+++ b/guide/zh/04-javascript-api.md
@@ -36,7 +36,7 @@ build();
 
 #### 输入参数(inputOptions)
 
-`inputOptions` 对象包含下列属性 (查看[big list of options](#big-list-of-options) 以获得这些参数更详细的资料):
+`inputOptions` 对象包含下列属性 (查看[big list of options](guide/zh#big-list-of-options) 以获得这些参数更详细的资料):
 
 ```js
 const inputOptions = {
@@ -60,7 +60,7 @@ const inputOptions = {
 
 #### 输出参数(outputOptions)
 
-`outputOptions` 对象包括下列属性 (查看 [big list of options](#big-list-of-options) 以获得这些参数更详细的资料):
+`outputOptions` 对象包括下列属性 (查看 [big list of options](guide/zh#big-list-of-options) 以获得这些参数更详细的资料):
 
 ```js
 const outputOptions = {
@@ -129,4 +129,4 @@ const watchOptions = {
 };
 ```
 
-查看以上文档知道更多 `inputOptions` 和 `outputOptions` 的细节, 或查询 [big list of options](#big-list-of-options) 关 `chokidar`, `include` 和 `exclude` 的资料。
+查看以上文档知道更多 `inputOptions` 和 `outputOptions` 的细节, 或查询 [big list of options](guide/zh#big-list-of-options) 关 `chokidar`, `include` 和 `exclude` 的资料。


### PR DESCRIPTION
### Background

The links to the `#big-list-of-options` in the docs are broken. They are marked as
```md
[big list of options](#big-list-of-options)
```
and lead to: https://rollupjs.org/#big-list-of-options

### Solution

This Commit prefixes the anchor link `#big-list-of-options` with the path to the corresponding guide.
```md
[big list of options](guide/en#big-list-of-options)
```
https://rollupjs.org/guide/en#big-list-of-options