### PR TITLE
Add sourcemapPathTransform option, renderStart and renderError hooks.

### DIFF
--- a/guide/en/01-command-line-reference.md
+++ b/guide/en/01-command-line-reference.md
@@ -68,6 +68,7 @@ export default { // can be an array (for multiple inputs)
     outro,
     sourcemap,
     sourcemapFile,
+    sourcemapPathTransform,
     interop,
     extend,
 

--- a/guide/en/02-javascript-api.md
+++ b/guide/en/02-javascript-api.md
@@ -87,6 +87,7 @@ const outputOptions = {
   outro,
   sourcemap,
   sourcemapFile,
+  sourcemapPathTransform,
   interop,
   extend,
 

--- a/guide/en/05-plugins.md
+++ b/guide/en/05-plugins.md
@@ -99,7 +99,7 @@ A `String`, or a `Function` that returns a `String` or `Promise`.
 Type: `Function`<br>
 Signature: `( outputOptions, bundle, isWrite ) => (void|Promise)`
 
-Called when `bundle.generate()` or `bundle.write()` is being executed. `bundle` provides the full list of files being written or generated along with their details.
+Called at the end of `bundle.generate()` or `bundle.write()`. `bundle` provides the full list of files being written or generated along with their details.
 
 #### `intro`
 Type: `String|Function`
@@ -122,6 +122,18 @@ Type: `Function`<br>
 Signature: `(code, { modules, exports, imports, fileName, isEntry }, outputOptions) => (code | { code, map} | Promise)`
 
 Can be used to transform individual chunks. Called for each Rollup output chunk file. Returning `null` will apply no transformations.
+
+#### `renderError`
+Type: `Function`<br>
+Signature: `( error ) => void`
+
+Called when rollup encounters an error during `bundle.generate()` or `bundle.write()`. The error is passed to this hook. To get notified when generation completes successfully, use the `generateBundle` hook.
+
+#### `renderStart`
+Type: `Function`<br>
+Signature: `( ) => (void|Promise)`
+
+Called initially each time `bundle.generate()` or `bundle.write()` is called. To get notified when generation has completed, use the `generateBundle` and `renderError` hooks.
 
 #### `resolveId`
 Type: `Function`<br>

--- a/guide/en/999-big-list-of-options.md
+++ b/guide/en/999-big-list-of-options.md
@@ -281,6 +281,26 @@ If `true`, a separate sourcemap file will be created. If `inline`, the sourcemap
 
 `sourcemapFile` is not required if `output` is specified, in which case an output filename will be inferred by adding ".map"  to the output filename for the bundle.
 
+#### output.sourcemapPathTransform
+
+`Function` A transformation to apply to each path in a sourcemap. For instance the following will change all paths to be relative to the `src` directory.
+
+```js
+import path from 'path';
+export default ({
+  input: 'src/main',
+  output: [{
+    file: 'bundle.js',
+    sourcemapPathTransform: relativePath => {
+      // will transform e.g. "src/main.js" -> "main.js"
+      return path.relative('src', relativePath)
+    },
+    format: 'esm',
+    sourcemap: true
+  }]
+});
+```
+
 #### output.interop *`--interop`/*`--no-interop`*
 
 `true` or `false` (defaults to `true`) – whether or not to add an 'interop block'. By default (`interop: true`), for safety's sake, Rollup will assign any external dependencies' `default` exports to a separate variable if it's necessary to distinguish between default and named exports. This generally only applies if your external dependencies were transpiled (for example with Babel) – if you're sure you don't need it, you can save a few bytes with `interop: false`.


### PR DESCRIPTION
An option and two hooks were missing from the 0.66.0 update. Those are added here.