### PR TITLE
Use bold font for code in headlines

### DIFF
--- a/routes/guide/[lang]/index.html
+++ b/routes/guide/[lang]/index.html
@@ -64,11 +64,20 @@
 		color: #333;
 	}
 
+    .content :global(h3) :global(code) {
+        font-weight: 700;
+    }
+
 	.content :global(h4) {
         padding-top: 4em;
 		margin: -3em 0 0.5em 0;
 		font-size: 1em;
-		color: #333;
+        font-weight: 700;
+        color: #333;
+	}
+
+	.content :global(h4) :global(code) {
+        font-weight: 700;
 	}
 
 	.content :global(h4) :global(em) {


### PR DESCRIPTION
Just a simple thing I noticed: When using inline code in headlines, the inline code is not in bold font as opposed to the rest of the headline and other headlines on the same level. This means that e.g. in the plugin section, the headlines hardly stick out.
This adjusts the styling.