### PR TITLE
Fix headers to not overlay content

### DIFF
--- a/routes/guide/[lang]/index.html
+++ b/routes/guide/[lang]/index.html
@@ -74,6 +74,7 @@
 		font-size: 1em;
         font-weight: 700;
         color: #333;
+		z-index: -1;
 	}
 
 	.content :global(h4) :global(code) {


### PR DESCRIPTION
Fixes #165.

I ran into it independently, found in the browser console I could make a quick z-index hack, and it seemed to work. This applies it to this so it just works. (It doesn't fix the underlying CSS issue of the headers being munged into the parent sections if the padding is removed, though.)