### PR TITLE
Add basic code splitting support

### DIFF
--- a/examples/06/example.json
+++ b/examples/06/example.json
@@ -1,0 +1,3 @@
+{
+	"title": "Dynamic imports"
+}

--- a/examples/06/modules/main.js
+++ b/examples/06/modules/main.js
@@ -1,0 +1,9 @@
+/* DYNAMIC IMPORTS
+   Rollup supports automatic chunking and lazy-loading
+   via dynamic imports utilizing the import mechanism
+   of the host system. */
+
+import('./maths.js').then(function (maths) {
+	console.log( maths.square( 5 ) );
+	console.log( maths.cube( 5 ) );
+});

--- a/examples/06/modules/maths.js
+++ b/examples/06/modules/maths.js
@@ -1,0 +1,6 @@
+import square from './square.js';
+export {default as square} from './square.js';
+
+export function cube (x ) {
+	return square(x) * x;
+}

--- a/examples/06/modules/square.js
+++ b/examples/06/modules/square.js
@@ -1,0 +1,3 @@
+export default function square ( x ) {
+	return x * x;
+}

--- a/routes/repl/_Input/index.html
+++ b/routes/repl/_Input/index.html
@@ -52,8 +52,6 @@
 
 <script>
 	import Module from './Module.html';
-	import { dirname, resolve, extname } from '../_utils/path';
-	// import examples from '../examples.js';
 
 	let uid = 1;
 

--- a/routes/repl/_Output/BundleOptions.html
+++ b/routes/repl/_Output/BundleOptions.html
@@ -9,31 +9,33 @@
 		{/each}
 	</section>
 
-	{#if options.format === 'amd' || options.format === 'umd'}
-		<section>
-			<h3>options.amd.id</h3>
-			<input bind:value='options.amd.id' placeholder='leave blank for anonymous module'>
-		</section>
-	{/if}
-
-	{#if options.format === 'iife' || options.format === 'umd'}
-		{#if exports.length}
+	{#if !error}
+		{#if options.format === 'amd' || options.format === 'umd'}
 			<section>
-				<h3>options.name</h3>
-				<input bind:value='options.name'>
+				<h3>options.amd.id</h3>
+				<input bind:value='options.amd.id' placeholder='leave blank for anonymous module'>
 			</section>
 		{/if}
 
-		{#if sortedImports.length}
-			<section>
-				<h3>options.globals</h3>
-				{#each sortedImports as x (x.name)}
-					<div>
-						<input bind:value='options.globals[x.name]'>
-						<code>'{x.name}'</code>
-					</div>
-				{/each}
-			</section>
+		{#if options.format === 'iife' || options.format === 'umd'}
+			{#if output[0].exports.length}
+				<section>
+					<h3>options.name</h3>
+					<input bind:value='options.name'>
+				</section>
+			{/if}
+
+			{#if sortedImports.length}
+				<section>
+					<h3>options.globals</h3>
+					{#each sortedImports as x (x.name)}
+						<div>
+							<input bind:value='options.globals[x.name]'>
+							<code>'{x.name}'</code>
+						</div>
+					{/each}
+				</section>
+			{/if}
 		{/if}
 	{/if}
 </div>
@@ -76,6 +78,7 @@
 
 	input {
 		padding-left: 1.5em;
+		background-color: #eee;
 	}
 
 	section code {
@@ -106,26 +109,23 @@
 				{ name: 'system', value: 'system' }
 			],
 
-			imports: [],
-			exports: [],
+			output: [],
 			sortedImports: []
 		}),
 
 		computed: {
-			sortedImports: ({ imports, options }) => {
+			sortedImports: ({ output, options }) => {
 				// we only care about this stuff in IIFE/UMD mode...
 				// cheeky hack to clean `options.globals`
 				const { format } = options;
 				if (format !== 'iife' && format !== 'umd') return [];
 
-				return imports
+				return output[0].imports
 					.sort((a, b) => a < b ? -1 : 1)
-					.map(name => {
-						return {
-							name,
-							value: userGlobals[name] || defaultGlobals[name] || name
-						};
-					});
+					.map(name => ({
+						name,
+						value: userGlobals[name] || defaultGlobals[name] || name
+					}));
 			}
 		},
 

--- a/routes/repl/_Output/index.html
+++ b/routes/repl/_Output/index.html
@@ -1,13 +1,35 @@
 <Status {error} {warnings}/>
-<BundleOptions bind:options {imports} {exports}/>
 
-<div class='output'>
-	<Editor {code} readonly/>
-</div>
+<BundleOptions bind:options {output} {error}/>
+
+{#if !error}
+	{#each output as chunk}
+		<article class='output'>
+			{#if output.length > 1}
+				<header>
+					<span class='module-name'>{chunk.fileName}</span>
+				</header>
+			{/if}
+
+			<Editor code={chunk.code} readonly/>
+		</article>
+	{/each}
+{/if}
 
 <style>
 	.output {
+		margin: 0 0 1em 0;
 		border: 1px solid #eee;
+	}
+
+	.module-name {
+		display: block;
+		padding: 0.5em;
+	}
+
+	header {
+		width: 100%;
+		border-bottom: 1px solid #f4f4f4;
 	}
 </style>
 

--- a/routes/repl/_utils/rollupVersion.js
+++ b/routes/repl/_utils/rollupVersion.js
@@ -1,0 +1,7 @@
+const isRollupVersionAtLeast = (major, minor) => {
+	const [currentMajor, currentMinor] = window.rollup.VERSION.split('.').map(Number);
+	return currentMajor > major || (currentMajor === major && currentMinor >= minor);
+};
+
+export const supportsInput = () => isRollupVersionAtLeast(0, 48);
+export const supportsCodeSplitting = () => isRollupVersionAtLeast(1, 0);

--- a/routes/repl/index.html
+++ b/routes/repl/index.html
@@ -6,9 +6,9 @@
 		</div>
 	</div>
 	<div class='right'>
-		<h2>...bundle comes out</h2>
+		<h2>...{#if output.length > 1}chunks come{:else}bundle comes{/if} out</h2>
 		<div class='output'>
-			<Output bind:options {code} {error} {warnings} {imports} {exports}/>
+			<Output bind:options {output} {error} {warnings}/>
 		</div>
 	</div>
 </div>
@@ -66,7 +66,7 @@
 	}
 
 	:global(input):focus {
-		background-color: #eee;
+		background-color: #eaeaea;
 	}
 
 
@@ -121,20 +121,19 @@
 
 		data () {
 			return {
-				code: '',
+				output: [],
 				rollupReady: false,
 
 				options: {
 					format: 'cjs',
 					name: 'myBundle',
-					amd: { id: '' }
+					amd: { id: '' },
+					globals: {}
 				},
 
 				selectedExample: null,
 				modules: [],
-				warnings: [],
-				imports: [],
-				exports: []
+				warnings: []
 			};
 		},
 
@@ -255,17 +254,13 @@
 
 					if (supportsCodeSplitting()) {
 						this.set({
-							code: generated.output[0].code,
-							imports: generated.output[0].imports,
-							exports: generated.output[0].exports,
+							output: generated.output,
 							error: null,
 							warnings
 						});
 					} else {
 						this.set({
-							code: generated.code,
-							imports: generated.imports,
-							exports: generated.exports,
+							output: [generated],
 							error: null,
 							warnings
 						});

--- a/routes/repl/index.html
+++ b/routes/repl/index.html
@@ -84,7 +84,8 @@
 	import Input from './_Input/index.html';
 	import Output from './_Output/index.html';
 	import debounce from './_utils/debounce.js';
-	import { dirname, resolve } from './_utils/path';
+	import {dirname, resolve} from './_utils/path';
+	import {supportsCodeSplitting, supportsInput} from './_utils/rollupVersion';
 
 	const versionMatch = typeof window !== 'undefined' ? /version=([^&]+)/.exec( window.location.search ) : null;
 
@@ -211,69 +212,64 @@
 				});
 
 				const warnings = [];
+				const inputOptions = {
+					plugins: [{
+						resolveId ( importee, importer ) {
+							if ( !importer ) return importee;
+							if ( importee[0] !== '.' ) return false;
+
+							let resolved = resolve( dirname( importer ), importee ).replace( /^\.\//, '' );
+							if ( resolved in moduleById ) return resolved;
+
+							resolved += '.js';
+							if ( resolved in moduleById ) return resolved;
+
+							throw new Error( `Could not resolve '${importee}' from '${importer}'` );
+						},
+						load: function ( id ) {
+							return moduleById[ id ].code;
+						}
+					}],
+					onwarn ( warning ) {
+						warnings.push( warning );
+
+						console.group( warning.loc ? warning.loc.file : '' );
+
+						console.warn( warning.message );
+
+						if ( warning.frame ) {
+							console.log( warning.frame );
+						}
+
+						if ( warning.url ) {
+							console.log( `See ${warning.url} for more information` );
+						}
+
+						console.groupEnd();
+					}
+				};
+				inputOptions[supportsInput() ? 'input' : 'entry'] = 'main.js';
 
 				try {
-					const bundle = await rollup.rollup({
-						input: 'main.js',
-						entry: 'main.js', // for older versions
-						plugins: [{
-							resolveId ( importee, importer ) {
-								if ( !importer ) return importee;
-								if ( importee[0] !== '.' ) return false;
+					const generated = await (await rollup.rollup(inputOptions)).generate(this.get().options);
 
-								let resolved = resolve( dirname( importer ), importee ).replace( /^\.\//, '' );
-								if ( resolved in moduleById ) return resolved;
-
-								resolved += '.js';
-								if ( resolved in moduleById ) return resolved;
-
-								throw new Error( `Could not resolve '${importee}' from '${importer}'` );
-							},
-							load: function ( id ) {
-								return moduleById[ id ].code;
-							}
-						}],
-						onwarn ( warning ) {
-							warnings.push( warning );
-
-							console.group( warning.loc ? warning.loc.file : '' );
-
-							console.warn( warning.message );
-
-							if ( warning.frame ) {
-								console.log( warning.frame );
-							}
-
-							if ( warning.url ) {
-								console.log( `See ${warning.url} for more information` );
-							}
-
-							console.groupEnd();
-						}
-					});
-
-					if (bundle.imports && bundle.exports) {
+					if (supportsCodeSplitting()) {
 						this.set({
-							imports: bundle.imports,
-							exports: bundle.exports
-						});
-					}
-
-					const { options } = this.get();
-					const generated = await bundle.generate(options);
-
-					// TODO support multiple chunks
-					if (generated.output) {
-						this.set({
+							code: generated.output[0].code,
 							imports: generated.output[0].imports,
-							exports: generated.output[0].exports
+							exports: generated.output[0].exports,
+							error: null,
+							warnings
+						});
+					} else {
+						this.set({
+							code: generated.code,
+							imports: generated.imports,
+							exports: generated.exports,
+							error: null,
+							warnings
 						});
 					}
-					this.set({
-						code: generated.output ? generated.output[0].code : generated.code,
-						error: null,
-						warnings
-					});
 				} catch(error) {
 					this.set({ error });
 					if ( error.frame ) console.log( error.frame );


### PR DESCRIPTION
This will add support for code-splitting via dynamic imports and automatically display multiple chunks if applicable. This also fixes support for `output.globals` in IIFE builds and improves some inconsistencies. I hope to add support for multiple entry points in a future PR.