### PR TITLE
suppress UNKNOWN_OPTION warning in REPL

### DIFF
--- a/routes/repl/index.html
+++ b/routes/repl/index.html
@@ -234,6 +234,10 @@
 							}
 						}],
 						onwarn ( warning ) {
+							if (warning.code === 'UNKNOWN_OPTION') {
+								return;
+							}
+
 							warnings.push( warning );
 
 							console.group( warning.loc ? warning.loc.file : '' );


### PR DESCRIPTION
*Probably* this is the simplest way to address this? There's currently an 'unknown option' warning displayed for every single thing that's bundled with the REPL, because it has to include both the new and old option names so it can work with multiple versions of Rollup. This just suppresses those warnings, which are nothing REPL users are going to be interested in.

Another option would be to query the Rollup version and call it according to what's supported in that version, but that sounds like a lot more work.