### PR TITLE
fix zh docs markdown link & blank space

### DIFF
--- a/guide/zh/05-tools.md
+++ b/guide/zh/05-tools.md
@@ -4,7 +4,7 @@ title: Rollup 与其他工具集成
 
 ### npm packages
 
-在某些时候，你的项目很可能依赖于从npm安装到你的`node_modules`文件夹中的软件包。 与Webpack和Browserify这样的其他捆绑包不同，Rollup不知道如何打破常规去处理这些依赖。 - 我们需要添加一些配置。
+在某些时候，你的项目很可能依赖于从 npm 安装到你的 `node_modules` 文件夹中的软件包。 与 Webpack 和 Browserify 这样的其他捆绑包不同，Rollup 不知道如何打破常规去处理这些依赖。 - 我们需要添加一些配置。
 
 让我们添加一个简单的依赖 [the-answer](https://www.npmjs.com/package/the-answer)，它输出对生活、宇宙及其它一切的答案
 
@@ -37,7 +37,7 @@ https://github.com/rollup/rollup/wiki/Troubleshooting#treating-module-as-externa
 the-answer (imported by main.js)
 ```
 
-打包后的`bundle.js`仍然会在 Node.js 中工作，因为`import`声明转变成了 CommonJS中的 `require` 语句，但是`the-answer`不包含在包中。因此，我们需要一个插件。
+打包后的 `bundle.js` 仍然会在 Node.js 中工作，因为 `import` 声明转变成了 CommonJS 中的 `require` 语句，但是 `the-answer` 不包含在包中。因此，我们需要一个插件。
 
 #### rollup-plugin-node-resolve
 
@@ -64,26 +64,26 @@ export default {
 };
 ```
 
-这次，当你运行 `npm run build`, 再没有警告输出 - 打包文件 bundle 包含了引用的模块。
+这次，当你运行 `npm run build` , 再没有警告输出 - 打包文件 bundle 包含了引用的模块。
 
 #### rollup-plugin-commonjs
 
-一些库导出成你可以正常导入的ES6模块 -`the-answer` 就是一个这样的模块。 但是目前，npm中的大多数包都是以CommonJS模块的形式出现的。 在它们更改之前，我们需要将CommonJS模块转换为 ES2015 供 Rollup 处理。
+一些库导出成你可以正常导入的 ES6 模块 - `the-answer` 就是一个这样的模块。 但是目前， npm 中的大多数包都是以 CommonJS 模块的形式出现的。 在它们更改之前，我们需要将 CommonJS 模块转换为 ES2015 供 Rollup 处理。
 
 这个 [rollup-plugin-commonjs](https://github.com/rollup/rollup-plugin-commonjs) 插件就是用来将 CommonJS 转换成 ES2015 模块的。
 
-请注意，`rollup-plugin-commonjs`应该用在其他插件转换你的模块*之前* - 这是为了防止其他插件的改变破坏CommonJS的检测。
+请注意， `rollup-plugin-commonjs` 应该用在其他插件转换你的模块*之前* - 这是为了防止其他插件的改变破坏 CommonJS 的检测。
 
 ### Peer dependencies
 
-假设你正在构建一个具有对等依赖关系（peer dependency）的库，例如React或Lodash。 如果你如上所述设置外部引用（externals），你的 Rollup 将把 所有 imports 的模块打包在一起：
+假设你正在构建一个具有对等依赖关系（peer dependency）的库，例如 React 或 Lodash 。 如果你如上所述设置外部引用（externals），你的 Rollup 将把 所有 imports 的模块打包在一起：
 
 ```js
 import answer from 'the-answer';
 import _ from 'lodash';
 ```
 
-你可以微调哪些导入是想要打包的，哪些是外部的引用（externals）。 对于这个例子，我们认为`lodash`是外部的引用（externals），而不是`the-answer`。
+你可以微调哪些导入是想要打包的，哪些是外部的引用（externals）。 对于这个例子，我们认为 `lodash` 是外部的引用（externals），而不是 `the-answer` 。
 
 这是配置文件:
 
@@ -108,9 +108,9 @@ export default {
 };
 ```
 
-这样，“lodash”现在将被视为外部的（externals），不会与你的库打包在一起。
+这样， `lodash` 现在将被视为外部的（externals），不会与你的库打包在一起。
 
-`external` 接受一个模块名称的数组或一个接受模块名称的函数，如果它被视为外部引用（externals）则返回true。 例如：
+`external` 接受一个模块名称的数组或一个接受模块名称的函数，如果它被视为外部引用（externals）则返回 true 。 例如：
 
 ```js
 export default {
@@ -119,25 +119,25 @@ export default {
 }
 ```
 
-如果你使用 [babel-plugin-lodash]（https://github.com/lodash/babel-plugin-lodash）来最优选择lodash模块，在这种情况下，Babel将转换你的导入语句，如下所示
+如果你使用 [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) 来最优选择 `lodash` 模块，在这种情况下， Babel 将转换你的导入语句，如下所示
 
 ```js
 import _merge from 'lodash/merge';
 ```
 
-“external”的数组形式不会处理通配符，所以这个导入只会以函数的形式被视作外部依赖/引用（externals）。
+`external` 的数组形式不会处理通配符，所以这个导入只会以函数的形式被视作外部依赖/引用（externals）。
 
 ### Babel
 
-许多开发人员在他们的项目中使用[Babel]（https://babeljs.io/），以便他们可以使用未被浏览器和Node.js支持的将来版本的 JavaScript 特性。
+许多开发人员在他们的项目中使用 [Babel](https://babeljs.io/) ，以便他们可以使用未被浏览器和 Node.js 支持的将来版本的 JavaScript 特性。
 
-使用 Babel 和 Rollup 的最简单方法是使用 [rollup-plugin-babel]（https://github.com/rollup/rollup-plugin-babel）。 安装它：
+使用 Babel 和 Rollup 的最简单方法是使用 [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel) 。 安装它：
 
 ```bash
 npm i -D rollup-plugin-babel
 ```
 
-添加到Rollup配置文件 `rollup.config.js`:
+添加到 Rollup 配置文件 `rollup.config.js`:
 
 ```js
 // rollup.config.js
@@ -159,7 +159,7 @@ export default {
 };
 ```
 
-在Babel实际编译代码之前，需要进行配置。 创建一个新文件`src/.babelrc`：
+在 Babel 实际编译代码之前，需要进行配置。 创建一个新文件`src/.babelrc`：
 
 ```js
 {
@@ -174,19 +174,19 @@ export default {
 }
 ```
 
-这个设置有一些不寻常的地方。首先，我们设置`"modules": false`，否则 Babel 会在 Rollup 有机会做处理之前，将我们的模块转成 CommonJS，导致 Rollup 的一些处理失败。
+这个设置有一些不寻常的地方。首先，我们设置 `"modules": false` ，否则 Babel 会在 Rollup 有机会做处理之前，将我们的模块转成 CommonJS ，导致 Rollup 的一些处理失败。
 
-其次，我们使用`external-helpers`插件，它允许 Rollup 在包的顶部只引用一次 “helpers”，而不是每个使用它们的模块中都引用一遍（这是默认行为）。
+其次，我们使用 `external-helpers` 插件，它允许 Rollup 在包的顶部只引用一次 `helpers` ，而不是每个使用它们的模块中都引用一遍（这是默认行为）。
 
-第三，我们将`.babelrc`文件放在`src`中，而不是根目录下。 这允许我们对于不同的任务有不同的`.babelrc`配置，比如像测试，如果我们以后需要的话 - 通常为单独的任务单独配置会更好。
+第三，我们将 `.babelrc` 文件放在 `src` 中，而不是根目录下。 这允许我们对于不同的任务有不同的 `.babelrc` 配置，比如像测试，如果我们以后需要的话 - 通常为单独的任务单独配置会更好。
 
-现在，在我们运行 rollup 之前，我们需要安装`latest` preset 和`external-helpers`插件
+现在，在我们运行 rollup 之前，我们需要安装 `latest` preset 和 `external-helpers` 插件
 
 ```bash
 npm i -D babel-preset-latest babel-plugin-external-helpers
 ```
 
-运行 Rollup 现在将创建一个 bundle 包... 实际上我们并没有使用任何ES2015特性。 我们来改变一下。 编辑`src / main.js`：
+运行 Rollup 现在将创建一个 bundle 包... 实际上我们并没有使用任何ES2015特性。 我们来改变一下。 编辑 `src / main.js` ：
 
 ```js
 // src/main.js
@@ -197,7 +197,7 @@ export default () => {
 }
 ```
 
-运行 Rollup `npm run build`，检查打包后的bundle：
+运行 Rollup `npm run build`，检查打包后的 bundle ：
 
 ```js
 'use strict';


### PR DESCRIPTION
- [x] Use English bracket replace Chinese symbol to fix zh docs markdown link.
- [x] Unify the style that leave blank space between Chinese and English.