### PR TITLE
Fix bold font on Windows

### DIFF
--- a/src/routes/guide/[lang]/index.svelte
+++ b/src/routes/guide/[lang]/index.svelte
@@ -161,7 +161,6 @@
 
 	.content :global(p) {
 		margin: 0 0 1em 0;
-		font-weight: 300;
 		color: #181818;
 		line-height: 1.5;
 	}

--- a/static/global.css
+++ b/static/global.css
@@ -24,7 +24,7 @@
 body {
 	margin: 0;
 	background: #fff;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI Semibold", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 	font-weight: 300;
 	color: #555;
 	line-height: 1.5;

--- a/static/global.css
+++ b/static/global.css
@@ -25,7 +25,6 @@ body {
 	margin: 0;
 	background: #fff;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-	font-weight: 300;
 	color: #555;
 	line-height: 1.5;
 	-webkit-font-smoothing: antialiased;


### PR DESCRIPTION
For some reason Windows users are getting bold text everywhere, let's fix that.
This change reverts #196

Before:

![image](https://user-images.githubusercontent.com/1462706/71530090-24f19000-28f9-11ea-92b4-bca824267c48.png)

After:
![image](https://user-images.githubusercontent.com/1462706/71530078-11462980-28f9-11ea-86a5-b6c9d929889f.png)
