### PR TITLE
Add sourcemaps to production

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,7 @@ const onwarn = (warning, onwarn) =>
 export default {
 	client: {
 		input: config.client.input(),
-		output: config.client.output(),
+		output: { ...config.client.output(), sourcemap: true },
 		plugins: [
 			replace({
 				preventAssignment: true,


### PR DESCRIPTION
This will enable source maps in the production build to allow debugging (e.g. via replay). Everything is open here!