### PR TITLE
Add table of contents to subsections

### DIFF
--- a/src/components/Guide.svelte
+++ b/src/components/Guide.svelte
@@ -110,15 +110,17 @@
 								{@html tocItem.text}
 							</a>
 
-							<ul>
-								{#each tocItem.subSubSections as subTocItem}
-									<li>
-										<a href="{base}#{subTocItem.id}">
-											{@html subTocItem.text}
-										</a>
-									</li>
-								{/each}
-							</ul>
+							{#if tocItem.subSubSections.length > 0}
+								<ul>
+									{#each tocItem.subSubSections as subTocItem}
+										<li>
+											<a href="{base}#{subTocItem.id}">
+												{@html subTocItem.text}
+											</a>
+										</li>
+									{/each}
+								</ul>
+							{/if}
 						</li>
 					{/each}
 				</ul>

--- a/src/components/Guide.svelte
+++ b/src/components/Guide.svelte
@@ -4,6 +4,8 @@
 	import drawerOpen from '../stores/drawerOpen';
 	import currentSection from '../stores/currentSection';
 
+	$: base = `guide/${lang}/`;
+
 	export let sections = [];
 	export let lang;
 	let container;
@@ -57,6 +59,8 @@
 	}
 
 	onMount(() => {
+		document.documentElement.lang = lang;
+
 		anchors = Array.from(container.querySelectorAll('section[id]'))
 			.concat(Array.from(container.querySelectorAll('h3[id]')))
 			.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
@@ -97,6 +101,29 @@
 				</a>
 				{section.metadata.title}
 			</h2>
+
+			{#if section.tocItems.length > 0}
+				<ul class="table-of-contents">
+					{#each section.tocItems as tocItem}
+						<li>
+							<a href="{base}#{tocItem.id}">
+								{@html tocItem.text}
+							</a>
+
+							<ul>
+								{#each tocItem.subSubSections as subTocItem}
+									<li>
+										<a href="{base}#{subTocItem.id}">
+											{@html subTocItem.text}
+										</a>
+									</li>
+								{/each}
+							</ul>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+
 			{@html section.html}
 		</section>
 	{/each}
@@ -173,6 +200,11 @@
 		font-size: 1.8em;
 		font-weight: 700;
 		color: #333;
+	}
+
+	.table-of-contents,
+	.table-of-contents ul {
+		padding-left: 1.5em;
 	}
 
 	.content :global(h3) {

--- a/src/components/Guide.svelte
+++ b/src/components/Guide.svelte
@@ -4,6 +4,8 @@
 	import drawerOpen from '../stores/drawerOpen';
 	import currentSection from '../stores/currentSection';
 
+	$: base = `guide/${lang}/`;
+
 	export let sections = [];
 	export let lang;
 	let container;
@@ -97,6 +99,25 @@
 				</a>
 				{section.metadata.title}
 			</h2>
+			<ul>
+				{#each section.subsections as subsection}
+					<li>
+						<a href="{base}#{subsection.slug}">
+							{subsection.title}
+						</a>
+
+						<ul>
+							{#each subsection.subsubsections as subsubsection}
+								<li>
+									<a href="{base}#{subsubsection.slug}">
+										{subsubsection.title}
+									</a>
+								</li>
+							{/each}
+						</ul>
+					</li>
+				{/each}
+			</ul>
 			{@html section.html}
 		</section>
 	{/each}

--- a/src/components/Guide.svelte
+++ b/src/components/Guide.svelte
@@ -96,7 +96,7 @@
 	{#each sections as section}
 		<section id="{section.slug}">
 			<h2>
-				<a class="anchor" href="guide/en/#{section.slug}">
+				<a class="anchor" href="{base}#{section.slug}">
 					<img src="/images/anchor.svg" alt="" />
 				</a>
 				{section.metadata.title}

--- a/src/components/Guide.svelte
+++ b/src/components/Guide.svelte
@@ -4,8 +4,6 @@
 	import drawerOpen from '../stores/drawerOpen';
 	import currentSection from '../stores/currentSection';
 
-	$: base = `guide/${lang}/`;
-
 	export let sections = [];
 	export let lang;
 	let container;
@@ -99,25 +97,6 @@
 				</a>
 				{section.metadata.title}
 			</h2>
-			<ul>
-				{#each section.subsections as subsection}
-					<li>
-						<a href="{base}#{subsection.slug}">
-							{subsection.title}
-						</a>
-
-						<ul>
-							{#each subsection.subsubsections as subsubsection}
-								<li>
-									<a href="{base}#{subsubsection.slug}">
-										{subsubsection.title}
-									</a>
-								</li>
-							{/each}
-						</ul>
-					</li>
-				{/each}
-			</ul>
 			{@html section.html}
 		</section>
 	{/each}

--- a/src/helpers/createGuide.js
+++ b/src/helpers/createGuide.js
@@ -58,7 +58,7 @@ function create_guide(lang) {
 				previousTocItem.subSubSections.push({ id, text });
 			}
 
-			return `<h${level} id="${id}"><a class="anchor" href="guide/en/#${id}"><img src="/images/anchor.svg" alt=""></a>${text}</h${level}>`;
+			return `<h${level} id="${id}"><a class="anchor" href="guide/${lang}/#${id}"><img src="/images/anchor.svg" alt=""></a>${text}</h${level}>`;
 		};
 
 		const html = marked(content, { renderer })

--- a/src/helpers/createGuide.js
+++ b/src/helpers/createGuide.js
@@ -61,24 +61,12 @@ function create_guide(lang) {
 			return `<h${level} id="${id}"><a class="anchor" href="guide/en/#${id}"><img src="/images/anchor.svg" alt=""></a>${text}</h${level}>`;
 		};
 
-		const initialHtml = marked(content, { renderer })
+		const html = marked(content, { renderer })
 			.replace(/<p>(<a class='open-in-repl'[\s\S]+?)<\/p>/g, '$1')
 			.replace(/<p>@@(\d+)<\/p>/g, (match, id) => {
 				return `<pre><code>${highlighted[id]}</code></pre>`;
 			})
 			.replace(/^\t+/gm, match => match.split('\t').join('  '));
-
-		const tocItemsMarkup = tocItems
-			.map(tocItem => {
-				const subTocItemsMarkup = tocItem.subSubSections
-					.map(subTocItem => `<li><a href="guide/en/#${subTocItem.id}">${subTocItem.text}</a></li>`)
-					.join('');
-				let subTocMarkup = subTocItemsMarkup.length > 0 ? `<ul>${subTocItemsMarkup}</ul>` : '';
-
-				return `<li><a href="guide/en/#${tocItem.id}">${tocItem.text}</a>${subTocMarkup}</li>`;
-			})
-			.join('');
-		const html = `<ul>${tocItemsMarkup}</ul>` + initialHtml;
 
 		const subsections = [];
 		const pattern = /<h3 id="(.+?)">(.+?)<\/h3>/g;
@@ -99,6 +87,7 @@ function create_guide(lang) {
 			html,
 			metadata,
 			subsections,
+			tocItems,
 			slug: file.replace(/^\d+-/, '').replace(/\.md$/, '')
 		};
 	});


### PR DESCRIPTION
Small disclaimer: Please read this pull request as a proposition. I don’t know if you even want to have this on your website. If not in this form, I hope another way can be found to improve the site’s navigability. Also, I have never worked with Svelte before so please let me know if any changes to the PR in its current form are required.

## Changes

Adds a generated, two-level deep table of contents to all subsections (i.e. to the documents found in the `guide/[lang]/` directories). The elements in the table of contents are plain links pointing to fragment identifiers of their corresponding heading elements (i.e. the heading elements’ ID attributes). This is intended to improve the navigability of the documentation especially for sections like “Plugin Development” and “Big list of options” which both have many, many sub sections.

Moves the chain of `String.prototype.replace` calls sanitizing heading markup into its own function because it’s now also needed for the logic preparing the new table of content data. Also adds two new calls replacing the HTML entities `&lt;` and `&gt;` which appear in some of the headings (e.g. https://rollupjs.org/guide/en/#-p-plugin---plugin-plugin).

## Motivation

Pretty regularly when working with Rollup, I get a bit frustrated when looking up the documentation for a certain feature or configuration option because the website is one big document that has no built-in search beyond what a browser offers. I tend to resort to searching the page using full-text search (e.g. via <kbd>Ctrl+F</kbd>) which becomes tedious quickly when trying to look up options one finds in example configurations, etc.

Being able to click on the “Big list of options” entry in the main table of contents in the sidebar and then having a list of all the options linked to their sections is something I wanted many, many times when working with Rollup before so I figured it’s time to (try to) make it happen.

## Miscellaneous

- I’ve ran `npm run lint` and `npm test` on this branch.